### PR TITLE
Add Firebase-based React celebration app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,36 +1,4 @@
-# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
-
-# dependencies
-/node_modules
-/.pnp
-.pnp.js
-
-# testing
-/coverage
-
-# next.js
-/.next/
-/out/
-
-# production
-/build
-
-# misc
+node_modules
+web/node_modules
+functions/node_modules
 .DS_Store
-*.pem
-
-# debug
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-
-# local env files
-.env*.local
-.env
-
-# vercel
-.vercel
-
-# typescript
-*.tsbuildinfo
-next-env.d.ts

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# celebrate-me
+# Celebrate Me
+
+This project is a playful React web app backed by Firebase. It creates a personalized birthday celebration experience for software teams. All UI logic runs on the front end and data about each session is stored in Firestore via Firebase Functions.
+
+## Development
+
+1. Install dependencies for the Firebase functions and the web app. (Requires internet access.)
+2. Deploy hosting and functions with Firebase CLI:
+
+```sh
+firebase deploy
+```
+
+During development you can serve the web files locally with any HTTP server.

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,12 @@
+{
+  "functions": {
+    "source": "functions"
+  },
+  "hosting": {
+    "public": "web",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      {"source": "/celebrate/**", "destination": "/index.html"}
+    ]
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /celebrations/{id} {
+      allow read, write: if true;
+    }
+  }
+}

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,25 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+const express = require('express');
+const cors = require('cors');
+admin.initializeApp();
+
+const db = admin.firestore();
+
+const app = express();
+app.use(cors({ origin: true }));
+
+app.post('/start', async (req, res) => {
+  const { name, persona, stats, scroll, trials } = req.body;
+  const docRef = await db.collection('celebrations').add({
+    name,
+    persona,
+    stats,
+    scroll,
+    trials,
+    timestamp: admin.firestore.FieldValue.serverTimestamp(),
+  });
+  res.json({ id: docRef.id, link: `/celebrate/${name}?id=${docRef.id}` });
+});
+
+exports.api = functions.https.onRequest(app);

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "celebrate-functions",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1",
+    "cors": "^2.8.5",
+    "express": "^4.18.2"
+  }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Birthday Protocol</title>
+    <script defer type="module" src="/src/app.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "celebrate-web",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "serve -s .",
+    "build": "echo build placeholder"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.3.0",
+    "firebase": "^10.6.0"
+  }
+}

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -1,0 +1,152 @@
+import React from 'https://unpkg.com/react@18/umd/react.development.js';
+import ReactDOM from 'https://unpkg.com/react-dom@18/umd/react-dom.development.js';
+import {
+  BrowserRouter,
+  Routes,
+  Route,
+  useParams,
+  useNavigate,
+} from 'https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js';
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.6.0/firebase-app.js';
+import { getFirestore, doc, setDoc } from 'https://www.gstatic.com/firebasejs/10.6.0/firebase-firestore.js';
+
+const firebaseConfig = {
+  // TODO: replace with your config
+};
+initializeApp(firebaseConfig);
+const db = getFirestore();
+
+const personas = [
+  { title: 'Patch Mage', desc: 'Conjurer of hotfixes' },
+  { title: 'Bug Whisperer', desc: 'Listens to stack traces' },
+  { title: 'PR Warrior', desc: 'Defender of code reviews' },
+];
+
+function randomItem(list) {
+  return list[Math.floor(Math.random() * list.length)];
+}
+
+function Landing() {
+  const { name } = useParams();
+  const navigate = useNavigate();
+  return (
+    <div style={{ textAlign: 'center', marginTop: '50px' }}>
+      <h1>Birthday Protocol Activated for {name}</h1>
+      <button onClick={() => navigate('scan')}>Begin the Ritual</button>
+    </div>
+  );
+}
+
+function Scan() {
+  const navigate = useNavigate();
+  const stats = {
+    mergeResistance: Math.floor(Math.random() * 100),
+    slackSpeed: Math.floor(Math.random() * 100),
+    burnout: Math.floor(Math.random() * 100),
+  };
+  return (
+    <div style={{ textAlign: 'center', marginTop: '50px' }}>
+      <h2>Scanning Dev DNA...</h2>
+      <p>Merge Conflict Resistance: {stats.mergeResistance}%</p>
+      <p>Slack Typing Speed: {stats.slackSpeed} wpm</p>
+      <p>Burnout Level: {stats.burnout}%</p>
+      <button onClick={() => navigate('../persona', { state: { stats } })}>Accept My Fate</button>
+    </div>
+  );
+}
+
+function Persona() {
+  const navigate = useNavigate();
+  const persona = randomItem(personas);
+  return (
+    <div style={{ textAlign: 'center', marginTop: '50px' }}>
+      <h2>{persona.title}</h2>
+      <p>{persona.desc}</p>
+      <button onClick={() => navigate('../trial', { state: { persona } })}>Reveal My Birthday Trials</button>
+    </div>
+  );
+}
+
+const trials = [
+  'Debug the build without coffee',
+  'Push to main on Friday afternoon',
+  'Merge a massive PR unseen',
+];
+
+const outcomes = [
+  'Prod exploded. QA just quit.',
+  'All tests passed magically.',
+  'A wild merge conflict appeared!',
+];
+
+function Trial() {
+  const navigate = useNavigate();
+  const [outcome, setOutcome] = React.useState(null);
+  function pickTrial(t) {
+    setOutcome(randomItem(outcomes));
+  }
+  return (
+    <div style={{ textAlign: 'center', marginTop: '50px' }}>
+      <h2>Choose your absurd challenge</h2>
+      {trials.map((t) => (
+        <p key={t}>
+          <button onClick={() => pickTrial(t)}>{t}</button>
+        </p>
+      ))}
+      {outcome && (
+        <div>
+          <p>{outcome}</p>
+          <button onClick={() => navigate('../scroll', { state: { outcome } })}>
+            Continue
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const scrolls = [
+  'May your commits be ever blessed.',
+  'The release gods favor you today.',
+  'Bug demons flee before your IDE.',
+];
+
+function Scroll() {
+  const navigate = useNavigate();
+  const message = randomItem(scrolls);
+  return (
+    <div style={{ textAlign: 'center', marginTop: '50px' }}>
+      <h2>Scroll of Honor</h2>
+      <p>{message}</p>
+      <button
+        onClick={async () => {
+          const params = new URLSearchParams(window.location.search);
+          const id = params.get('id');
+          const name = window.location.pathname.split('/')[2];
+          await setDoc(doc(db, 'celebrations', id), { finalMessage: message }, { merge: true });
+          navigator.clipboard.writeText(message);
+          alert('Copied to clipboard');
+        }}
+      >
+        Copy to Slack
+      </button>
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="celebrate/:name" element={<Landing />} />
+        <Route path="celebrate/:name/scan" element={<Scan />} />
+        <Route path="celebrate/:name/persona" element={<Persona />} />
+        <Route path="celebrate/:name/trial" element={<Trial />} />
+        <Route path="celebrate/:name/scroll" element={<Scroll />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));
+


### PR DESCRIPTION
## Summary
- set up Firebase hosting config and permissive Firestore rules
- scaffold simple Cloud Function to store celebration sessions
- create lightweight React front-end with celebratory pages
- document project setup

## Testing
- `npm run build` *(fails: registry access blocked)*
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_685ad3e38eb48330a93a42219cc7061b